### PR TITLE
Update jekyll.yml ruby-setup

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Ruby
-        uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42 # v1.161.0
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3.0' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically


### PR DESCRIPTION
The github pages build was failing: so we're now using the ruby-setup that will automatically keep itself updated. This is the official recommendation -> https://github.com/ruby/setup-ruby/blob/f6e05710eced3c9c28e489afdc6fd8a3bc685325/README.md?plain=1#L238-L248

I'm hoping dependabot will also alert us in the future if anything needs to change.